### PR TITLE
Update Ruby version in GitHub Actions workflow

### DIFF
--- a/.github/workflows/js_from_routes.yml
+++ b/.github/workflows/js_from_routes.yml
@@ -6,7 +6,7 @@ on:
       - main
   pull_request:
     branches:
-      - '**'
+      - "**"
 
 jobs:
   rspec:
@@ -16,16 +16,14 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        ruby: [
-          "3.2",
-          "3.3",
-        ]
-        gemfile: [
-          "Gemfile-rails.7.2.x",
-          "Gemfile-rails.8.0.x",
-        ]
+        ruby: ["3.2", "3.3", "3.4"]
+        gemfile: ["Gemfile-rails.7.2.x", "Gemfile-rails.8.0.x"]
         experimental: [false]
         include:
+          - ruby: "4.0"
+            os: ubuntu-22.04
+            gemfile: Gemfile-rails-edge
+            experimental: true
           - ruby: "4.0"
             os: ubuntu-latest
             gemfile: Gemfile-rails-edge
@@ -39,12 +37,15 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: '18'
+          node-version: "18"
 
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby }}
           bundler-cache: true
+
+      - name: Install Dependencies
+        run: sudo apt-get install libreadline-dev
 
       - name: Setup Code Climate test-reporter
         if: ${{ contains(github.ref, 'main') }}
@@ -88,7 +89,7 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 18.x
-          cache: 'pnpm'
+          cache: "pnpm"
 
       - run: pnpm install --frozen-lockfile
 

--- a/.github/workflows/js_from_routes.yml
+++ b/.github/workflows/js_from_routes.yml
@@ -35,9 +35,6 @@ jobs:
         with:
           node-version: "18"
 
-      - name: Install Readline dependencies
-        run: sudo apt-get update && sudo apt-get install -y libreadline-dev
-
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby }}

--- a/.github/workflows/js_from_routes.yml
+++ b/.github/workflows/js_from_routes.yml
@@ -26,7 +26,7 @@ jobs:
         ]
         experimental: [false]
         include:
-          - ruby: "3.4.0-preview2"
+          - ruby: "4.0"
             os: ubuntu-latest
             gemfile: Gemfile-rails-edge
             experimental: true

--- a/.github/workflows/js_from_routes.yml
+++ b/.github/workflows/js_from_routes.yml
@@ -21,10 +21,6 @@ jobs:
         experimental: [false]
         include:
           - ruby: "4.0"
-            os: ubuntu-22.04
-            gemfile: Gemfile-rails-edge
-            experimental: true
-          - ruby: "4.0"
             os: ubuntu-latest
             gemfile: Gemfile-rails-edge
             experimental: true
@@ -39,13 +35,13 @@ jobs:
         with:
           node-version: "18"
 
+      - name: Install Readline dependencies
+        run: sudo apt-get update && sudo apt-get install -y libreadline-dev
+
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby }}
           bundler-cache: true
-
-      - name: Install Dependencies
-        run: sudo apt-get install libreadline-dev
 
       - name: Setup Code Climate test-reporter
         if: ${{ contains(github.ref, 'main') }}

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -194,6 +194,7 @@ DEPENDENCIES
   listen (~> 3.2)
   pry-byebug (~> 3.9)
   rake (~> 13)
+  reline (~> 0.6)
   rspec-given (~> 3.8)
   simplecov (< 0.18)
   standard (~> 1.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -189,7 +189,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  bundler (~> 2)
+  bundler (>= 2, < 5)
   js_from_routes!
   listen (~> 3.2)
   pry-byebug (~> 3.9)
@@ -199,4 +199,4 @@ DEPENDENCIES
   standard (~> 1.0)
 
 BUNDLED WITH
-   2.3.22
+  4.0.3

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -120,6 +120,8 @@ GEM
       ffi (~> 1.0)
     rdoc (6.10.0)
       psych (>= 4.0.0)
+    readline (0.0.4)
+      reline
     regexp_parser (2.9.2)
     reline (0.6.0)
       io-console (~> 0.5)
@@ -194,7 +196,7 @@ DEPENDENCIES
   listen (~> 3.2)
   pry-byebug (~> 3.9)
   rake (~> 13)
-  reline (~> 0.6)
+  readline
   rspec-given (~> 3.8)
   simplecov (< 0.18)
   standard (~> 1.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -120,6 +120,8 @@ GEM
       ffi (~> 1.0)
     rdoc (6.10.0)
       psych (>= 4.0.0)
+    readline (0.0.4)
+      reline
     regexp_parser (2.9.2)
     reline (0.6.0)
       io-console (~> 0.5)
@@ -194,6 +196,7 @@ DEPENDENCIES
   listen (~> 3.2)
   pry-byebug (~> 3.9)
   rake (~> 13)
+  readline
   rspec-given (~> 3.8)
   simplecov (< 0.18)
   standard (~> 1.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -120,8 +120,6 @@ GEM
       ffi (~> 1.0)
     rdoc (6.10.0)
       psych (>= 4.0.0)
-    readline (0.0.4)
-      reline
     regexp_parser (2.9.2)
     reline (0.6.0)
       io-console (~> 0.5)
@@ -196,7 +194,6 @@ DEPENDENCIES
   listen (~> 3.2)
   pry-byebug (~> 3.9)
   rake (~> 13)
-  readline
   rspec-given (~> 3.8)
   simplecov (< 0.18)
   standard (~> 1.0)

--- a/js_from_routes/js_from_routes.gemspec
+++ b/js_from_routes/js_from_routes.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency "railties", ">= 5.1", "< 9"
 
-  s.add_development_dependency "bundler", "~> 2"
+  s.add_development_dependency "bundler", ">= 2", "< 5"
   s.add_development_dependency "listen", "~> 3.2"
   s.add_development_dependency "pry-byebug", "~> 3.9"
   s.add_development_dependency "rake", "~> 13"

--- a/js_from_routes/js_from_routes.gemspec
+++ b/js_from_routes/js_from_routes.gemspec
@@ -18,6 +18,9 @@ Gem::Specification.new do |s|
   s.add_development_dependency "bundler", ">= 2", "< 5"
   s.add_development_dependency "listen", "~> 3.2"
   s.add_development_dependency "pry-byebug", "~> 3.9"
+  # TODO: track https://github.com/deivid-rodriguez/pry-byebug/issues/460
+  # probably could be removed after the issue is fixed
+  s.add_development_dependency "readline"
   s.add_development_dependency "rake", "~> 13"
   s.add_development_dependency "rspec-given", "~> 3.8"
   s.add_development_dependency "simplecov", "< 0.18"

--- a/js_from_routes/js_from_routes.gemspec
+++ b/js_from_routes/js_from_routes.gemspec
@@ -18,6 +18,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency "bundler", ">= 2", "< 5"
   s.add_development_dependency "listen", "~> 3.2"
   s.add_development_dependency "pry-byebug", "~> 3.9"
+  s.add_development_dependency "reline", '~> 0.6'
   s.add_development_dependency "rake", "~> 13"
   s.add_development_dependency "rspec-given", "~> 3.8"
   s.add_development_dependency "simplecov", "< 0.18"

--- a/js_from_routes/js_from_routes.gemspec
+++ b/js_from_routes/js_from_routes.gemspec
@@ -18,7 +18,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency "bundler", ">= 2", "< 5"
   s.add_development_dependency "listen", "~> 3.2"
   s.add_development_dependency "pry-byebug", "~> 3.9"
-  s.add_development_dependency "readline"
   s.add_development_dependency "rake", "~> 13"
   s.add_development_dependency "rspec-given", "~> 3.8"
   s.add_development_dependency "simplecov", "< 0.18"

--- a/js_from_routes/js_from_routes.gemspec
+++ b/js_from_routes/js_from_routes.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency "bundler", ">= 2", "< 5"
   s.add_development_dependency "listen", "~> 3.2"
   s.add_development_dependency "pry-byebug", "~> 3.9"
-  s.add_development_dependency "reline", '~> 0.6'
+  s.add_development_dependency "readline"
   s.add_development_dependency "rake", "~> 13"
   s.add_development_dependency "rspec-given", "~> 3.8"
   s.add_development_dependency "simplecov", "< 0.18"

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -7,6 +7,12 @@ SimpleCov.start {
 require "rails"
 require "js_from_routes"
 require "rspec/given"
-require "pry-byebug"
+
+puts "------"*10
+ENV.each { |k, v| puts "#{k}=#{v}" }
+puts "------"*10
+unless ENV["CI"] == "true" || ENV["GITHUB_ACTIONS"] == "true"
+  require "pry-byebug"
+end
 
 $LOAD_PATH.push File.expand_path("../playground", __dir__)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -7,12 +7,7 @@ SimpleCov.start {
 require "rails"
 require "js_from_routes"
 require "rspec/given"
+require "pry-byebug"
 
-puts "------"*10
-ENV.each { |k, v| puts "#{k}=#{v}" }
-puts "------"*10
-unless ENV["CI"] == "true" || ENV["GITHUB_ACTIONS"] == "true"
-  require "pry-byebug"
-end
 
 $LOAD_PATH.push File.expand_path("../playground", __dir__)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -7,7 +7,5 @@ SimpleCov.start {
 require "rails"
 require "js_from_routes"
 require "rspec/given"
-require "pry-byebug"
-
 
 $LOAD_PATH.push File.expand_path("../playground", __dir__)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -7,5 +7,6 @@ SimpleCov.start {
 require "rails"
 require "js_from_routes"
 require "rspec/given"
+require "pry-byebug"
 
 $LOAD_PATH.push File.expand_path("../playground", __dir__)


### PR DESCRIPTION
The experimental Rails edge job was failing, probably due to `3.4.0-preview2` not being available on `ubuntu-latest`.

This pull request updates the Ruby version for that job to ensure compatibility with the latest Ruby release which I guess was the initial point of having that preview version.

Ruby 4.0 ships with Bundler 4.x, but the gemspec constrained `bundler ~> 2`, causing version resolution failures in CI.

**Changes:**
- `js_from_routes.gemspec`: Updated bundler dependency from `~> 2` to `>= 2, < 5` to support both Bundler 2.x (Ruby 3.x) and Bundler 4.x (Ruby 4.0+)

* [`.github/workflows/js_from_routes.yml`](diffhunk://#diff-d39208c4b8d4ab46b16517faca7e40c915ea325b9655e436cba54a787da29678L29-R29): Changed the Ruby version for the experimental Rails edge job from `3.4.0-preview2` to `4.0`.

This allows the experimental Rails edge job to run successfully with Ruby 4.0 while maintaining compatibility with existing Ruby 3.x builds.